### PR TITLE
Schedule + Billing + Roster alignment (Wizard v2) [Droid-assisted]

### DIFF
--- a/backend/routes/loom.js
+++ b/backend/routes/loom.js
@@ -96,16 +96,20 @@ router.get('/instances', async (req, res) => {
     // Query loom_instances table for instances within date range
     const query = `
       SELECT 
-        id, 
-        source_rule_id, 
-        instance_date, 
-        start_time, 
-        end_time, 
-        venue_id,
+        li.id,
+        li.source_rule_id,
+        li.instance_date,
+        li.start_time,
+        li.end_time,
+        li.venue_id,
+        rp.name AS program_name,
+        v.name  AS venue_name,
         'planned' AS status
-      FROM loom_instances
-      WHERE instance_date BETWEEN $1 AND $2
-      ORDER BY instance_date ASC, start_time ASC
+      FROM loom_instances li
+      JOIN rules_programs rp ON li.source_rule_id = rp.id
+      LEFT JOIN venues v       ON rp.venue_id = v.id
+      WHERE li.instance_date BETWEEN $1 AND $2
+      ORDER BY li.instance_date ASC, li.start_time ASC
     `;
     
     const result = await pool.query(query, [startDate, endDate]);

--- a/backend/routes/roster.js
+++ b/backend/routes/roster.js
@@ -59,14 +59,12 @@ router.get('/day', async (req, res) => {
     const instancesPromises = instancesResult.rows.map(async (instance) => {
       // Count participants for this instance
       const participantsResult = await pool.query(`
-        SELECT COUNT(*) as participant_count
-        FROM rules_participant_schedule
-        WHERE program_id = $1
-          AND start_date <= $2
-          AND (end_date IS NULL OR end_date >= $2)
-      `, [instance.source_rule_id, date]);
-      
-      const participantCount = parseInt(participantsResult.rows[0].participant_count) || 0;
+        SELECT COUNT(*)::int AS participant_count
+        FROM rules_program_participants
+        WHERE rule_id = $1
+      `, [instance.source_rule_id]);
+
+      const participantCount = participantsResult.rows[0]?.participant_count || 0;
       
       // Calculate staff and vehicle requirements
       const staffRequired = Math.ceil(participantCount / staffThreshold);

--- a/backend/routes/util_generateBilling.js
+++ b/backend/routes/util_generateBilling.js
@@ -1,0 +1,274 @@
+/**
+ * Billing Generator Utility
+ * 
+ * Generates payment_diamonds entries from rules_program_participants and their
+ * associated billing lines in rules_program_participant_billing.
+ */
+
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * Ensure payment_diamonds has required columns (idempotent)
+ * @param {Object} pool - Database connection pool
+ * @returns {Promise<void>}
+ */
+const ensurePaymentDiamondsColumns = async (pool) => {
+  try {
+    // Add program_id column if it doesn't exist
+    await pool.query(`
+      ALTER TABLE payment_diamonds 
+      ADD COLUMN IF NOT EXISTS program_id UUID NULL
+    `);
+    
+    // Add hours column if it doesn't exist
+    await pool.query(`
+      ALTER TABLE payment_diamonds 
+      ADD COLUMN IF NOT EXISTS hours NUMERIC(6,2) NULL
+    `);
+    
+    console.log('[BILLING] Ensured payment_diamonds has program_id and hours columns');
+  } catch (err) {
+    // Ignore errors if columns already exist or other issues
+    console.error('[BILLING] Note: payment_diamonds column check:', err.message);
+  }
+};
+
+/**
+ * Generate billing entries from rules and participants
+ * @param {Object} options - Generation options
+ * @param {string} [options.ruleId] - Optional specific rule ID to process
+ * @param {string} options.dateFrom - Start date in YYYY-MM-DD format
+ * @param {string} options.dateTo - End date in YYYY-MM-DD format
+ * @param {Object} pool - Database connection pool
+ * @returns {Promise<Object>} - Summary of the generation operation
+ */
+async function generateBilling(options = {}, pool) {
+  // Validate pool parameter
+  if (!pool) {
+    throw new Error('generateBilling requires a database pool');
+  }
+
+  // Extract and validate options
+  const { ruleId, dateFrom, dateTo } = options;
+  
+  if (!dateFrom || !dateTo) {
+    throw new Error('dateFrom and dateTo are required');
+  }
+
+  // Initialize summary counters
+  const summary = {
+    instancesScanned: 0,
+    linesCreated: 0,
+    linesSkipped: 0,
+    errors: 0
+  };
+
+  try {
+    // Ensure payment_diamonds has required columns
+    await ensurePaymentDiamondsColumns(pool);
+    
+    // Build query to get loom instances in date range
+    let instanceQuery = `
+      SELECT 
+        li.id, 
+        li.source_rule_id, 
+        li.instance_date,
+        rp.name as program_name
+      FROM loom_instances li
+      JOIN rules_programs rp ON li.source_rule_id = rp.id
+      WHERE li.instance_date BETWEEN $1 AND $2
+    `;
+    
+    const queryParams = [dateFrom, dateTo];
+    
+    // Add rule filter if provided
+    if (ruleId) {
+      instanceQuery += ` AND li.source_rule_id = $3`;
+      queryParams.push(ruleId);
+    }
+    
+    // Order by date for predictable processing
+    instanceQuery += ` ORDER BY li.instance_date ASC`;
+    
+    // Get all instances in the date range
+    const instancesResult = await pool.query(instanceQuery, queryParams);
+    const instances = instancesResult.rows;
+    
+    // Process each instance
+    for (const instance of instances) {
+      summary.instancesScanned++;
+      
+      try {
+        // Get all participants linked to this rule
+        const participantsResult = await pool.query(`
+          SELECT 
+            rpp.id as rpp_id, 
+            rpp.participant_id,
+            p.first_name || ' ' || p.last_name AS participant_name,
+            p.plan_management_type
+          FROM rules_program_participants rpp
+          JOIN participants p ON rpp.participant_id = p.id
+          WHERE rpp.rule_id = $1
+        `, [instance.source_rule_id]);
+        
+        const participants = participantsResult.rows;
+        
+        // For each participant, get their billing lines
+        for (const participant of participants) {
+          // Check for billing lines in the newer schema first
+          const billingResult = await pool.query(`
+            SELECT 
+              rppb.id,
+              rppb.billing_code_id,
+              rppb.hours,
+              rppb.ratio_label,
+              rppb.unit_price,
+              br.code as billing_code,
+              br.description as billing_description
+            FROM rules_program_participant_billing rppb
+            LEFT JOIN billing_rates br ON rppb.billing_code_id = br.id
+            WHERE rppb.rule_participant_id = $1
+          `, [participant.rpp_id]);
+          
+          // If no results, try legacy schema with rpp_id
+          let billingLines = billingResult.rows;
+          if (billingLines.length === 0) {
+            try {
+              const legacyResult = await pool.query(`
+                SELECT 
+                  rppb.id,
+                  rppb.billing_code,
+                  rppb.hours,
+                  '1:1' as ratio_label,
+                  0 as unit_price
+                FROM rules_program_participant_billing rppb
+                WHERE rppb.rpp_id = $1
+              `, [participant.rpp_id]);
+              
+              billingLines = legacyResult.rows;
+            } catch (legacyErr) {
+              // Ignore legacy schema errors - table might not exist or have different columns
+              console.log('[BILLING] Note: Legacy billing schema check failed:', legacyErr.message);
+            }
+          }
+          
+          // Process each billing line
+          for (const line of billingLines) {
+            try {
+              // Get or resolve billing code and unit price
+              let billingCode = line.billing_code || '';
+              let unitPrice = parseFloat(line.unit_price) || 0;
+              
+              // If we have a billing_code_id but no resolved code, try to get it directly
+              if (line.billing_code_id && !billingCode) {
+                try {
+                  const codeResult = await pool.query(`
+                    SELECT code, base_rate FROM billing_rates WHERE id = $1
+                  `, [line.billing_code_id]);
+                  
+                  if (codeResult.rows.length > 0) {
+                    billingCode = codeResult.rows[0].code;
+                    // If no unit price set, use base rate
+                    if (unitPrice === 0) {
+                      unitPrice = parseFloat(codeResult.rows[0].base_rate) || 0;
+                    }
+                  }
+                } catch (codeErr) {
+                  console.error('[BILLING] Error resolving billing code:', codeErr.message);
+                }
+              }
+              
+              // Skip if no billing code
+              if (!billingCode) {
+                summary.linesSkipped++;
+                continue;
+              }
+              
+              // Check if identical line already exists
+              const existingCheck = await pool.query(`
+                SELECT id FROM payment_diamonds 
+                WHERE participant_id = $1
+                AND program_id = $2
+                AND invoice_date = $3
+                AND support_item_number = $4
+                AND hours = $5
+                AND unit_price = $6
+              `, [
+                participant.participant_id,
+                instance.source_rule_id,
+                instance.instance_date,
+                billingCode,
+                line.hours,
+                unitPrice
+              ]);
+              
+              if (existingCheck.rows.length > 0) {
+                summary.linesSkipped++;
+                continue;
+              }
+              
+              // Calculate total amount
+              const hours = parseFloat(line.hours) || 0;
+              const quantity = 1; // Default quantity
+              const totalAmount = Math.round((unitPrice * hours * quantity) * 100) / 100;
+              
+              // Insert payment diamond
+              await pool.query(`
+                INSERT INTO payment_diamonds (
+                  id,
+                  participant_id,
+                  program_id,
+                  support_item_number,
+                  unit_price,
+                  hours,
+                  quantity,
+                  total_amount,
+                  gst_code,
+                  status,
+                  invoice_date,
+                  history_shift_id
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+              `, [
+                uuidv4(),
+                participant.participant_id,
+                instance.source_rule_id,
+                billingCode,
+                unitPrice,
+                hours,
+                quantity,
+                totalAmount,
+                'FRE', // GST-free
+                'pending',
+                instance.instance_date,
+                null // No history shift for generated entries
+              ]);
+              
+              summary.linesCreated++;
+              
+            } catch (lineErr) {
+              console.error('[BILLING] Error processing billing line:', lineErr.message);
+              summary.errors++;
+            }
+          }
+        }
+      } catch (instanceErr) {
+        console.error(`[BILLING] Error processing instance ${instance.id}:`, instanceErr.message);
+        summary.errors++;
+        // Continue with next instance despite error
+      }
+    }
+    
+    // Log generation summary
+    console.log(`[BILLING] Generated ${summary.linesCreated} billing lines from ${summary.instancesScanned} instances (${summary.linesSkipped} skipped, ${summary.errors} errors)`);
+    
+    return summary;
+  } catch (err) {
+    console.error('[BILLING] Error in generateBilling:', err.message);
+    throw err;
+  }
+}
+
+module.exports = {
+  generateBilling,
+  ensurePaymentDiamondsColumns
+};

--- a/frontend/src/pages/MasterSchedule.jsx
+++ b/frontend/src/pages/MasterSchedule.jsx
@@ -94,6 +94,28 @@ const MasterSchedule = () => {
     }
   };
   
+  // Delete a rule and refresh instances
+  const handleDeleteRule = async (ruleId) => {
+    if (!ruleId) return;
+    const confirmMsg =
+      'Delete this program template and all its scheduled instances?';
+    if (!window.confirm(confirmMsg)) return;
+
+    try {
+      await axios.delete(
+        `${API_URL}/api/v1/templates/rules/${ruleId}`
+      );
+      // Refresh current window
+      fetchInstancesForRange(windowDates);
+    } catch (err) {
+      console.error(
+        `Failed DELETE ${API_URL}/api/v1/templates/rules/${ruleId}`,
+        err?.response?.status
+      );
+      window.alert('Failed to delete program – see console for details.');
+    }
+  };
+
   // Get instances for a specific day
   const getInstancesForDay = (dateStr) => {
     // normalise both DB string and target day to YYYY-MM-DD to avoid TZ issues
@@ -172,7 +194,17 @@ const MasterSchedule = () => {
               ) : getInstancesForDay(dateObj.date).length > 0 ? (
                 getInstancesForDay(dateObj.date).map(instance => (
                   <div key={instance.id} className="program-card glass-card">
-                    <h3>{instance.source_rule_id}</h3>
+                    <button
+                      className="delete-btn"
+                      title="Delete program"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteRule(instance.source_rule_id);
+                      }}
+                    >
+                      ×
+                    </button>
+                    <h3>{instance.program_name || instance.source_rule_id}</h3>
                     <p className="time">
                       {formatTime(instance.start_time)} - {formatTime(instance.end_time)}
                     </p>

--- a/frontend/src/pages/MasterSchedule.jsx
+++ b/frontend/src/pages/MasterSchedule.jsx
@@ -96,7 +96,9 @@ const MasterSchedule = () => {
   
   // Get instances for a specific day
   const getInstancesForDay = (dateStr) => {
-    return instances.filter(instance => instance.instance_date === dateStr);
+    // normalise both DB string and target day to YYYY-MM-DD to avoid TZ issues
+    const norm = (d) => new Date(d).toISOString().split('T')[0];
+    return instances.filter(instance => norm(instance.instance_date) === dateStr);
   };
   
   // Format day header

--- a/frontend/src/styles/MasterSchedule.css
+++ b/frontend/src/styles/MasterSchedule.css
@@ -195,6 +195,7 @@
 .program-card {
   padding: 15px;
   margin-bottom: 10px;
+  position: relative; /* allow absolutely-positioned child controls */
   cursor: pointer;
   transition: all var(--transition-speed) ease;
 }
@@ -245,6 +246,30 @@
   transition: all var(--transition-speed) ease;
 }
 
+/* -------------------------------------------------------------------- */
+/* Inline delete button for program cards                               */
+/* -------------------------------------------------------------------- */
+.program-card .delete-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  line-height: 22px;
+  text-align: center;
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background var(--transition-speed) ease, transform var(--transition-speed) ease;
+}
+
+.program-card .delete-btn:hover {
+  background: var(--error-color);
+  transform: scale(1.05);
+}
 .empty-day:hover {
   border-color: rgba(255, 255, 255, 0.4);
   background: rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
This PR aligns schedule display, billing generation, and roster counts around the Wizard v2 rules flow.\n\nChanges:\n- MasterSchedule: normalize instance_date comparisons to prevent TZ/string mismatches\n- Backend: add util_generateBilling to produce payment_diamonds from rule staging\n- Templates: finalize now triggers generateBilling for the same window; include summary in response/logs\n- Finance: add POST /finance/generate-from-rules for manual/bulk generation with date defaults from org settings\n- Roster: participant counts now sourced from rules_program_participants via loom_instances.source_rule_id\n- Templates: DELETE /templates/rules/:id to cascade cleanup (slots, participants, staged billing, placeholders, loom_instances, event_card_map, cached requirements, and generated diamonds)\n\nValidation:\n- Frontend builds successfully (vite)\n- Pre-commit hooks passed\n- Server already running locally; endpoints verified for syntax and schema idempotency\n\nFollow-ups (optional):\n- Align loom POST/PUT schema to use instance_date/source_rule_id consistently or mark legacy endpoints.\n\n